### PR TITLE
Add 'format' option to support PNG output

### DIFF
--- a/ImageMarkupBuilder.js
+++ b/ImageMarkupBuilder.js
@@ -252,8 +252,9 @@ function ImageMarkupBuilder(fabricCanvas) {
     */
    function writeCanvas(callback) {
       fabricCanvas.renderAll();
-      var outstream = require('fs').createWriteStream(innerJSON.destinationFile),
-      stream = fabricCanvas.createJPEGStream({
+      var outstream = require('fs').createWriteStream(innerJSON.destinationFile);
+      var methodName = innerJSON.format === 'png' ? 'createPNGStream' : 'createJPEGStream';
+      var stream = fabricCanvas[methodName]({
          quality: 93,
          progressive: true
       });

--- a/ImageMarkupCall.js
+++ b/ImageMarkupCall.js
@@ -33,7 +33,7 @@ function processArgs() {
       usage();
    }
 
-   var shadows = 
+   var shadows =
       typeof(argv.shadows) == 'undefined'
       ? false
       : argv.shadows == 'true' || argv.shadows == true;
@@ -60,14 +60,14 @@ function processArgs() {
          stroke = Int(argv.stroke);
       }
 
-      convertMarkupToJSON(processJSON, argv.markup, argv.input, argv.output);
+      convertMarkupToJSON(processJSON, argv.markup, argv.input, argv.output, argv.format);
    } else {
       console.error('Invalid uage.');
       usage(-1);
    }
 }
 
-function convertMarkupToJSON(callback, markup, infile, outfile) {
+function convertMarkupToJSON(callback, markup, infile, outfile, format) {
    var json = {};
 
    var GM = require('gm');
@@ -191,6 +191,8 @@ function convertMarkupToJSON(callback, markup, infile, outfile) {
 
       json['sourceFile'] = infile;
       json['destinationFile'] = outfile;
+      json['format'] = format || 'jpeg';
+
 
       if (stroke != null) {
          json.instructions.strokeWidth = stroke;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies"    : {
     "fabric"      : "https://github.com/iFixit/fabric.js.git"
-   ,"optimist"    : "https://github.com/substack/node-optimist.git"
+   ,"optimist"    : "^0.6.1"
    ,"gm"          : ">=1.8.1"
   },
   "version"         : "0.0.2"


### PR DESCRIPTION
Part of [DOZ-893](https://dzki.atlassian.net/browse/DOZ-893). 

This simply adds an option for the output format, so that `node-markup` can produce either JPGs or PNGs. 

If the format option is not passed, it defaults to JPG.